### PR TITLE
little typos, double colon and dateset

### DIFF
--- a/src/train/data.py
+++ b/src/train/data.py
@@ -6,7 +6,7 @@ import torchvision.transforms as T
 import random
 
 
-class Subject200KDateset(Dataset):
+class Subject200KDataset(Dataset):
     def __init__(
         self,
         base_dataset,

--- a/src/train/train.py
+++ b/src/train/train.py
@@ -9,7 +9,7 @@ from datasets import load_dataset
 
 from .data import (
     ImageConditionDataset,
-    Subject200KDateset,
+    Subject200KDataset,
     CartoonDataset
 )
 from .model import OminiModel
@@ -84,7 +84,7 @@ def main():
             num_proc=16,
             cache_file_name="./cache/dataset/data_valid.arrow",
         )
-        dataset = Subject200KDateset(
+        dataset = Subject200KDataset(
             data_valid,
             condition_size=training_config["dataset"]["condition_size"],
             target_size=training_config["dataset"]["target_size"],
@@ -111,7 +111,7 @@ def main():
             drop_text_prob=training_config["dataset"]["drop_text_prob"],
             drop_image_prob=training_config["dataset"]["drop_image_prob"],
         )
-    elif training_config["dataset"]["type"] == "cartoon"::
+    elif training_config["dataset"]["type"] == "cartoon":
         dataset = load_dataset("saquiboye/oye-cartoon", split="train")
         dataset = CartoonDataset(
             dataset,


### PR DESCRIPTION
I noticed that there is a syntax error in the code where `::` is used. Specifically, in the line 114 of `train.py`:

```python
elif training_config["dataset"]["type"] == "cartoon"::
```
The double colons (`::`) seem to be a typo, as they result in a syntax error. At least from my understanding, this is not valid Python syntax. Could someone clarify the intended usage here or confirm if this is indeed an error that needs to be fixed?

Also, I fixed a minor typo that doesn’t cause an error but should still be corrected (`Subject200KDateset` -> `Subject200KDataset`).