### PR TITLE
Fix Module Import Path for Package Structure

### DIFF
--- a/src/flux/lora_controller.py
+++ b/src/flux/lora_controller.py
@@ -1,6 +1,6 @@
 from peft.tuners.tuners_utils import BaseTunerLayer
 from typing import List, Any, Optional, Type
-from condition import condition_dict
+from .condition import condition_dict
 
 class enable_lora:
     def __init__(self, lora_modules: List[BaseTunerLayer], activated: bool) -> None:


### PR DESCRIPTION
Here's a PR description for your change:

## Changes Made
- Modified the import statement in lora_controller.py from:
  ```python
  from condition import condition_dict
  ```
  to:
  ```python
  from .condition import condition_dict
  ```

## Reason for Change
- Fixed module import error when running the project as a package using `python -m src.gradio.gradio_app`
- Implements proper relative import syntax for Python package structure
- Ensures consistent module resolution across different execution contexts

## Testing
- Verified that the application runs successfully with `python -m src.gradio.gradio_app`
- Import resolution works correctly within the package hierarchy

## Impact
- No functional changes to the codebase
- Only affects import path resolution
- Improves package maintainability and deployment reliability