### PR TITLE
fix: Remove duplicate encode_images call in Condition.encode method

### DIFF
--- a/src/flux/condition.py
+++ b/src/flux/condition.py
@@ -118,7 +118,6 @@ class Condition(object):
                 tokens, ids = encode_images(pipe, e_condition)
             else:
                 tokens, ids = encode_images(pipe, self.condition)
-            tokens, ids = encode_images(pipe, self.condition)
         else:
             raise NotImplementedError(
                 f"Condition type {self.condition_type} not implemented"


### PR DESCRIPTION
Hello, I realized that my previous commit used an unregistered email address, which prevented my contribution from being properly recognized on GitHub.
To correct this, I updated my commit author information and force-pushed the branch.
Please let me know if this causes any issues or if I should take any further action.
Thank you for your understanding.