### PR TITLE
Fix LOCAL_RANK fallback for single GPU

### DIFF
--- a/omini/train_flux/train_custom.py
+++ b/omini/train_flux/train_custom.py
@@ -27,7 +27,7 @@ def main():
     # Initialize
     config = get_config()
     training_config = config["train"]
-    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK")))
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
     # Initialize custom dataset
     dataset = CustomDataset()

--- a/omini/train_flux/train_multi_condition.py
+++ b/omini/train_flux/train_multi_condition.py
@@ -118,7 +118,7 @@ def main():
     # Initialize
     config = get_config()
     training_config = config["train"]
-    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK")))
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
     # Initialize dataset
     dataset = load_dataset(

--- a/omini/train_flux/train_spatial_alignment.py
+++ b/omini/train_flux/train_spatial_alignment.py
@@ -171,7 +171,7 @@ def main():
     # Initialize
     config = get_config()
     training_config = config["train"]
-    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK")))
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
     # Load dataset text-to-image-2M
     dataset = load_dataset(

--- a/omini/train_flux/train_subject.py
+++ b/omini/train_flux/train_subject.py
@@ -152,7 +152,7 @@ def main():
     # Initialize
     config = get_config()
     training_config = config["train"]
-    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK")))
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
     # Initialize raw dataset
     raw_dataset = load_dataset("Yuanshi/Subjects200K")

--- a/omini/train_flux/train_token_integration.py
+++ b/omini/train_flux/train_token_integration.py
@@ -97,7 +97,7 @@ def main():
     # Initialize
     config = get_config()
     training_config = config["train"]
-    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK")))
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
     # Load dataset text-to-image-2M
     dataset = load_dataset(


### PR DESCRIPTION
## Summary
- default `LOCAL_RANK` environment variable to `0` when setting CUDA device

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68662cea187c832782da3329d1b5f65a